### PR TITLE
Fix stray script tag

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -37,6 +37,5 @@
       </div>
     <script src="/js/main.js?{{ assetHash }}"></script>
     {% block scripts %}{% endblock %}
-    <script src=> </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove blank script tag from the base layout

## Testing
- `npm run build` *(fails: eleventy not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864208e57f0832585048bd5982a3ee1