### PR TITLE
Make logo responsive for narrow viewports

### DIFF
--- a/src/css/blocks/site-head.css
+++ b/src/css/blocks/site-head.css
@@ -65,7 +65,7 @@
     transform: rotate(0deg) scale(1);
 }
 
-@media (max-width: 50rem) {
+@media (max-width: 40rem) {
     .with-js .site-header__nav-toggle {
         display: flex;
     }
@@ -76,6 +76,11 @@
 
     [aria-expanded=true]+.site-header__nav {
         display: block;
+    }
+
+    .site-header__logos {
+        width: clamp(4em, 12vw, 5.5em);
+        height: clamp(4em, 12vw, 5.5em);
     }
 }
 


### PR DESCRIPTION
Fix CSS class mismatch and implement fluid sizing for the phenakistoscope logo to reduce vertical space on mobile devices. Logo now scales from 4em on narrow viewports to 8em on wider screens using clamp(), with tighter vertical spacing for better mobile UX.